### PR TITLE
Drop ruby ree and 1.8.7 from travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,5 @@ script: bundle exec rspec spec
 rvm:
   - 2.0.0
   - 1.9.3
-  - 1.8.7
-  - ree
   - rbx-19mode
   - jruby-19mode
-matrix:
-  exclude:
-    - rvm: 1.8.7
-      gemfile: gemfiles/Gemfile.rails-4.0.rb
-    - rvm: ree
-      gemfile: gemfiles/Gemfile.rails-4.0.rb


### PR DESCRIPTION
The ree and 1.8.7 ruby versions are not supported anymore upstream.
As they trigger build errors on travis and would need some love, we
drop them instead.