### PR TITLE
Removing alias_method_chain methods for deprecation warnings

### DIFF
--- a/lib/seo_meta/instance_methods.rb
+++ b/lib/seo_meta/instance_methods.rb
@@ -10,19 +10,16 @@ module SeoMeta
           end
 
           # Allow attributes supplied to override the current seo_meta_attributes.
-          def attributes_with_seo_meta
-            seo_meta_attributes.merge(attributes_without_seo_meta)
+          def attributes
+            seo_meta_attributes.merge(super)
           end
 
-          alias_method_chain :attributes, :seo_meta
-
-          def attributes_equals_with_seo_meta(attributes, *args)
+          def attributes_equals(attributes, *args)
             seo_meta_attributes.merge(attributes)
-            attributes_equals_without_seo_meta
+            super
           end
 
           alias_method :attributes_equals, :attributes=
-          alias_method_chain :attributes_equals, :seo_meta
         end
       end
     end

--- a/spec/models/seo_meta_spec.rb
+++ b/spec/models/seo_meta_spec.rb
@@ -14,23 +14,23 @@ module SeoMeta
 
     context 'responds to' do
       it 'meta_description' do
-        dummy_for_spec.should respond_to(:meta_description)
+        expect(dummy_for_spec).to respond_to(:meta_description)
       end
 
       it 'browser_title' do
-        dummy_for_spec.should respond_to(:browser_title)
+        expect(dummy_for_spec).to respond_to(:browser_title)
       end
     end
 
     context 'allows us to assign to' do
       it 'meta_description' do
         dummy_for_spec.meta_description = 'This is my description of the dummy_for_spec for search results.'
-        dummy_for_spec.meta_description.should == 'This is my description of the dummy_for_spec for search results.'
+        expect(dummy_for_spec.meta_description).to eq('This is my description of the dummy_for_spec for search results.')
       end
 
       it 'browser_title' do
         dummy_for_spec.browser_title = 'An awesome browser title for SEO'
-        dummy_for_spec.browser_title.should == 'An awesome browser title for SEO'
+        expect(dummy_for_spec.browser_title).to eq('An awesome browser title for SEO')
       end
     end
 
@@ -40,7 +40,7 @@ module SeoMeta
         dummy_for_spec.save
 
         dummy_for_spec.reload
-        dummy_for_spec.meta_description.should == 'This is my description of the dummy_for_spec for search results.'
+        expect(dummy_for_spec.meta_description).to eq('This is my description of the dummy_for_spec for search results.')
       end
 
       it 'browser_title' do
@@ -48,7 +48,7 @@ module SeoMeta
         dummy_for_spec.save
 
         dummy_for_spec.reload
-        dummy_for_spec.browser_title.should == 'An awesome browser title for SEO'
+        expect(dummy_for_spec.browser_title).to eq('An awesome browser title for SEO')
       end
     end
 


### PR DESCRIPTION
Hello @parndt ! 😄 

In this PR I removed the `alias_method_chain` method in `lib/seo_meta/instance_methods.rb`, so we don't get any deprecation warnings in the RefineryCMS with rails 5.* by this gem. This is also the only file where the `alias_method_chain` method was used.